### PR TITLE
Session4: Mixin パターンを適用

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,19 @@
   },
   "files.watcherExclude": {
     "**/.fvm": true
+  },
+  "editor.multiCursorModifier": "alt",
+  "editor.guides.bracketPairs": true,
+  "dart.renameFilesWithClasses": "always",
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit"
+  },
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    "pubspec.yaml": ".flutter-plugins, .packages, .dart_tool, .flutter-plugins-dependencies, .metadata, .packages, pubspec.lock, build.yaml, analysis_options.yaml, all_lint_rules.yaml",
+    ".gitignore": ".gitattributes, .gitmodules, .gitmessage, .mailmap, .git-blame*",
+    "readme.*": "authors, backers.md, changelog*, citation*, code_of_conduct.md, codeowners, contributing.md, contributors, copying, credits, governance.md, history.md, license*, maintainers, readme*, security.md, sponsors.md",
+    "*.dart": "$(capture).g.dart, $(capture).freezed.dart"
   }
 }

--- a/lib/router_config.dart
+++ b/lib/router_config.dart
@@ -20,7 +20,7 @@ final routerConfig = GoRouter(
 class FirstScreenRoute extends GoRouteData {
   const FirstScreenRoute();
 
-  static const path = '/firestScreen';
+  static const path = '/firstScreen';
 
   @override
   Widget build(BuildContext context, GoRouterState state) {

--- a/lib/ui/first_screen.dart
+++ b/lib/ui/first_screen.dart
@@ -29,6 +29,6 @@ class _FirstScreenState extends State<FirstScreen> with OnEndOfFrameMixin {
     if (mounted) {
       await const WeatherPageRoute().push<void>(context);
     }
-    unawaited(executeOnEndOfFrame());
+    unawaited(_navigateToWeather());
   }
 }

--- a/lib/ui/first_screen.dart
+++ b/lib/ui/first_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_training/router_config.dart';
+import 'package:flutter_training/ui/on_end_of_frame_mixin.dart';
 
 class FirstScreen extends StatefulWidget {
   const FirstScreen({super.key});
@@ -10,26 +11,24 @@ class FirstScreen extends StatefulWidget {
   State<FirstScreen> createState() => _FirstScreenState();
 }
 
-class _FirstScreenState extends State<FirstScreen> {
-  @override
-  void initState() {
-    super.initState();
-
-    unawaited(_navigateToWeather());
-  }
+class _FirstScreenState extends State<FirstScreen> with OnEndOfFrameMixin {
 
   @override
   Widget build(BuildContext context) {
     return const ColoredBox(color: Colors.green);
   }
 
+  @override
+  Future<void> actionOnEndOfFrame() async {
+    unawaited(_navigateToWeather());
+  }
+
   Future<void> _navigateToWeather() async {
-    await WidgetsBinding.instance.endOfFrame;
     const fiveSeconds = Duration(milliseconds: 500);
     await Future<void>.delayed(fiveSeconds);
     if (mounted) {
       await const WeatherPageRoute().push<void>(context);
     }
-    unawaited(_navigateToWeather());
+    unawaited(executeOnEndOfFrame());
   }
 }

--- a/lib/ui/on_end_of_frame_mixin.dart
+++ b/lib/ui/on_end_of_frame_mixin.dart
@@ -1,0 +1,18 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+mixin OnEndOfFrameMixin<T extends StatefulWidget> on State<T> {
+  @override
+  void initState() {
+    super.initState();
+    unawaited(executeOnEndOfFrame());
+
+  }
+
+  Future<void> executeOnEndOfFrame() async {
+    await WidgetsBinding.instance.endOfFrame;
+
+    debugPrint('画面が表示された後に実行される処理');
+  }
+}

--- a/lib/ui/on_end_of_frame_mixin.dart
+++ b/lib/ui/on_end_of_frame_mixin.dart
@@ -13,6 +13,8 @@ mixin OnEndOfFrameMixin<T extends StatefulWidget> on State<T> {
   Future<void> executeOnEndOfFrame() async {
     await WidgetsBinding.instance.endOfFrame;
 
-    debugPrint('画面が表示された後に実行される処理');
+    unawaited(actionOnEndOfFrame());
   }
+
+  Future<void> actionOnEndOfFrame();
 }

--- a/lib/ui/on_end_of_frame_mixin.dart
+++ b/lib/ui/on_end_of_frame_mixin.dart
@@ -7,7 +7,6 @@ mixin OnEndOfFrameMixin<T extends StatefulWidget> on State<T> {
   void initState() {
     super.initState();
     unawaited(executeOnEndOfFrame());
-
   }
 
   Future<void> executeOnEndOfFrame() async {


### PR DESCRIPTION
## 課題

close #5 

## 対応箇所
- [x] typo修正
- [x] レイアウトが表示された後に「何かしらの処理」を行う [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) を作成する
- [x] 作成した [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) の使用先で「何かしらの処理」を記述できるようにする
- [x] [Session3](https://github.com/yuk1ch1/flutter-training-20240325/issues/4) で作成した以下の処理を作成した [Mixin](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) を使って書き直す
> 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する



## 動作

変更ないので省略
